### PR TITLE
All public API (except `MultiGetAsync`) is now non-throwing, expiration now acts as it is written in spec

### DIFF
--- a/src/Aer.Memcached.Client/Config/MemcachedConfiguration.cs
+++ b/src/Aer.Memcached.Client/Config/MemcachedConfiguration.cs
@@ -11,22 +11,22 @@ public class MemcachedConfiguration
     public const int DefaultMemcachedPort = 11211;
 
     /// <summary>
-    /// The default sync endpoint
+    /// The default sync endpoint.
     /// </summary>
     public const string DefaultSyncEndpoint = "/memcached/multi-store";
     
     /// <summary>
-    /// The default delete endpoint
+    /// The default delete endpoint.
     /// </summary>
     public const string DefaultDeleteEndpoint = "/memcached/multi-delete";
     
     /// <summary>
-    /// The default flush endpoint
+    /// The default flush endpoint.
     /// </summary>
     public const string DefaultFlushEndpoint = "/memcached/flush";
     
     /// <summary>
-    /// List of servers with hosted memcached
+    /// List of servers with hosted memcached.
     /// </summary>
     public Server[] Servers { get; set; }
     
@@ -42,12 +42,12 @@ public class MemcachedConfiguration
     public int MemcachedPort { get; set; } = DefaultMemcachedPort;
 
     /// <summary>
-    /// Configuration of <see cref="ConnectionPool.SocketPool"/>
+    /// Configuration of <see cref="ConnectionPool.SocketPool"/>.
     /// </summary>
     public SocketPoolConfiguration SocketPool { get; set; } = SocketPoolConfiguration.DefaultConfiguration();
 
     /// <summary>
-    /// Configuration of maintainer
+    /// Configuration of maintainer.
     /// </summary>
     public MaintainerConfiguration MemcachedMaintainer { get; set; } = MaintainerConfiguration.DefaultConfiguration();
     
@@ -59,17 +59,17 @@ public class MemcachedConfiguration
     public MemcachedDiagnosticsSettings Diagnostics { get; set; } = new();
     
     /// <summary>
-    /// Enables additional jitter for key expiration if property is not null
+    /// Enables additional jitter for key expiration if property is not null.
     /// </summary>
     public ExpirationJitterSettings ExpirationJitter { get; set; }
     
     /// <summary>
-    /// Sync settings to store data in multiple clusters
+    /// Sync settings to store data in multiple clusters.
     /// </summary>
     public SynchronizationSettings SyncSettings { get; set; }
 
     /// <summary>
-    /// Checks that either <see cref="HeadlessServiceAddress"/> or <see cref="Servers"/> are specified
+    /// Checks that either <see cref="HeadlessServiceAddress"/> or <see cref="Servers"/> are specified.
     /// </summary>
     public bool IsConfigured()
     {
@@ -112,17 +112,17 @@ public class MemcachedConfiguration
     public class SocketPoolConfiguration
     {
         /// <summary>
-        /// Amount of time after which the connection attempt will fail
+        /// Amount of time after which the connection attempt will fail.
         /// </summary>
         public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(1);
 
         /// <summary>
-        /// Amount of time after which receiving data from the socket will fail
+        /// Amount of time after which receiving data from the socket will fail.
         /// </summary>
         public TimeSpan ReceiveTimeout { get; set; } = TimeSpan.FromSeconds(1);
 
         /// <summary>
-        /// Amount of time to acquire socket from pool
+        /// Amount of time to acquire socket from pool.
         /// </summary>
         public TimeSpan SocketPoolingTimeout { get; set; } = TimeSpan.FromMilliseconds(150);
 
@@ -133,7 +133,7 @@ public class MemcachedConfiguration
         public int MaximumSocketCreationAttempts { get; set; } = 50;
 
         /// <summary>
-        /// Maximum amount of sockets per memcached instance in the socket pool
+        /// Maximum amount of sockets per memcached instance in the socket pool.
         /// </summary>
         public int MaxPoolSize { get; set; } = 100;
 
@@ -176,19 +176,19 @@ public class MemcachedConfiguration
     public class MaintainerConfiguration
     {
         /// <summary>
-        /// Period to rebuild nodes in <see cref="INodeLocator{TNode}"/>
+        /// Period to rebuild nodes in <see cref="INodeLocator{TNode}"/>.
         /// </summary>
         public TimeSpan? NodesRebuildingPeriod { get; set; } = TimeSpan.FromSeconds(15);
 
         /// <summary>
-        /// Period to check if nodes are responsive
+        /// Period to check if nodes are responsive.
         /// If node is not responded during <see cref="SocketPoolConfiguration.ConnectionTimeout"/> it is marked as dead
-        /// and will be deleted from node locator until it is responsive again
+        /// and will be deleted from node locator until it is responsive again.
         /// </summary>
         public TimeSpan? NodesHealthCheckPeriod { get; set; } = TimeSpan.FromSeconds(15);
 
         /// <summary>
-        /// Enables health check of nodes to remove dead nodes
+        /// Enables health check of nodes to remove dead nodes.
         /// </summary>
         public bool NodeHealthCheckEnabled { get; set; } = true;
         
@@ -220,7 +220,7 @@ public class MemcachedConfiguration
     public class ExpirationJitterSettings
     {
         /// <summary>
-        /// Initial number of seconds is got by last digits of calculated hash
+        /// Initial number of seconds is got by last digits of calculated hash.
         /// Number of digits depends on <see cref="SpreadFactor"/>,
         /// be default it is the remainder of the division by <see cref="SpreadFactor"/> = 2 digits
         /// Then it is multiplied by this factor to get final expiration time
@@ -235,44 +235,44 @@ public class MemcachedConfiguration
     public class SynchronizationSettings
     {
         /// <summary>
-        /// Endpoint that is created by current service to allow other services to sync data
+        /// Endpoint that is created by current service to allow other services to sync data.
         /// </summary>
         public string SyncEndpoint { get; set; } = DefaultSyncEndpoint;
         
         /// <summary>
-        /// Endpoint that is created by current service to allow other services to delete data
+        /// Endpoint that is created by current service to allow other services to delete data.
         /// </summary>
         public string DeleteEndpoint { get; set; } = DefaultDeleteEndpoint;
         
         /// <summary>
-        /// Endpoint that is created by current service to allow other services to flush data
+        /// Endpoint that is created by current service to allow other services to flush data.
         /// </summary>
         public string FlushEndpoint { get; set; } = DefaultFlushEndpoint;
         
         /// <summary>
-        /// Name of environment variable to get current cluster name
+        /// Name of environment variable to get current cluster name.
         /// It is needed to filter out sync servers and don't try to send data
-        /// to a service itself
+        /// to a service itself.
         /// </summary>
         public string ClusterNameEnvVariable { get; set; }
 
         /// <summary>
-        /// Number of retries to send data to a sync server
+        /// Number of retries to send data to a sync server.
         /// </summary>
         public int RetryCount { get; set; } = 3;
 
         /// <summary>
-        /// Time to sync data before a task is cancelled
+        /// Time to sync data before a task is cancelled.
         /// </summary>
         public TimeSpan TimeToSync { get; set; } = TimeSpan.FromSeconds(1);
         
         /// <summary>
-        /// Sync Servers
+        /// Sync Servers.
         /// </summary>
         public SyncServer[] SyncServers { get; set; }
         
         /// <summary>
-        /// Settings of circuit breaker
+        /// Settings of circuit breaker.
         /// </summary>
         public CacheSyncCircuitBreakerSettings CacheSyncCircuitBreaker { get; set; }
     }
@@ -280,12 +280,12 @@ public class MemcachedConfiguration
     public class SyncServer
     {
         /// <summary>
-        /// Http address of a server
+        /// Http address of a server.
         /// </summary>
         public string Address { get; set; }
         
         /// <summary>
-        /// Name of a cluster
+        /// Name of a cluster.
         /// </summary>
         public string ClusterName { get; set; }
     }
@@ -293,17 +293,17 @@ public class MemcachedConfiguration
     public class CacheSyncCircuitBreakerSettings
     {
         /// <summary>
-        /// Time window for counting errors
+        /// Time window for counting errors.
         /// </summary>
         public TimeSpan Interval { get; set; } = TimeSpan.FromSeconds(15);
 
         /// <summary>
-        /// Max errors in the <see cref="Interval"/>
+        /// Max errors in the <see cref="Interval"/>.
         /// </summary>
         public int MaxErrors { get; set; } = 50;
 
         /// <summary>
-        /// When <see cref="MaxErrors"/> reached switch of sync to a server for <see cref="SwitchOffTime"/>
+        /// When <see cref="MaxErrors"/> reached switch of sync to a server for <see cref="SwitchOffTime"/>.
         /// </summary>
         public TimeSpan SwitchOffTime { get; set; } = TimeSpan.FromMinutes(5);
     }

--- a/src/Aer.Memcached.Client/ExpirationCalculator.cs
+++ b/src/Aer.Memcached.Client/ExpirationCalculator.cs
@@ -72,7 +72,7 @@ public class ExpirationCalculator: IExpirationCalculator
         if (expirationTime.Value <= utcNow)
         {
             // means expiration time is in the past - don't save anything
-            return new Dictionary<string, uint>();
+            return null;
         }
 
         var timeSpan = expirationTime.Value.Subtract(utcNow);

--- a/src/Aer.Memcached.Client/ExpirationCalculator.cs
+++ b/src/Aer.Memcached.Client/ExpirationCalculator.cs
@@ -23,7 +23,7 @@ public class ExpirationCalculator: IExpirationCalculator
     /// <inheritdoc />
     public uint GetExpiration(string key, TimeSpan? expirationTime)
     {
-        if (IsInifiniteExpiration(expirationTime))
+        if (IsInfiniteExpiration(expirationTime))
         {
             return 0;
         }
@@ -45,7 +45,7 @@ public class ExpirationCalculator: IExpirationCalculator
     /// <inheritdoc />
     public Dictionary<string, uint> GetExpiration(IEnumerable<string> keys, TimeSpan? expirationTime)
     {
-        if (IsInifiniteExpiration(expirationTime))
+        if (IsInfiniteExpiration(expirationTime))
         {
             return keys.ToDictionary(k => k, _ => 0U);
         }
@@ -60,7 +60,7 @@ public class ExpirationCalculator: IExpirationCalculator
     /// <inheritdoc />
     public Dictionary<string, uint> GetExpiration(IEnumerable<string> keys, DateTimeOffset? expirationTime)
     {
-        if (IsInifiniteExpiration(expirationTime))
+        if (IsInfiniteExpiration(expirationTime))
         {
             return keys.ToDictionary(k => k, _ => 0U);
         }
@@ -123,13 +123,13 @@ public class ExpirationCalculator: IExpirationCalculator
         => (uint)(timeOffset + expirationTime).ToUnixTimeSeconds();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsInifiniteExpiration(TimeSpan? expirationTime) 
+    private static bool IsInfiniteExpiration(TimeSpan? expirationTime) 
         => !expirationTime.HasValue
         || expirationTime == TimeSpan.MaxValue
         || expirationTime == TimeSpan.Zero;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsInifiniteExpiration(DateTimeOffset? expirationTime) 
+    private static bool IsInfiniteExpiration(DateTimeOffset? expirationTime) 
         => !expirationTime.HasValue
         || expirationTime == DateTimeOffset.MaxValue;
 }

--- a/src/Aer.Memcached.Client/ExpirationCalculator.cs
+++ b/src/Aer.Memcached.Client/ExpirationCalculator.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Aer.ConsistentHash.Abstractions;
 using Aer.Memcached.Client.Config;
 using Aer.Memcached.Client.Interfaces;
@@ -21,11 +23,13 @@ public class ExpirationCalculator: IExpirationCalculator
     /// <inheritdoc />
     public uint GetExpiration(string key, TimeSpan? expirationTime)
     {
-        if (!expirationTime.HasValue)
+        if (IsInifiniteExpiration(expirationTime))
         {
             return 0;
         }
 
+        Debug.Assert(expirationTime != null, nameof(expirationTime) + " != null");
+        
         var utcNow = DateTimeOffset.UtcNow;
 
         if (_expirationJitterSettings == null)
@@ -33,7 +37,7 @@ public class ExpirationCalculator: IExpirationCalculator
             return GetExpirationTimeInUnixTimeSeconds(utcNow, expirationTime.Value);
         }
 
-        var expirationWithJitter = GetExpirationWithJitter(key, expirationTime);
+        var expirationWithJitter = GetExpirationWithJitter(key, expirationTime.Value);
 
         return GetExpirationTimeInUnixTimeSeconds(utcNow, expirationWithJitter);
     }
@@ -41,21 +45,37 @@ public class ExpirationCalculator: IExpirationCalculator
     /// <inheritdoc />
     public Dictionary<string, uint> GetExpiration(IEnumerable<string> keys, TimeSpan? expirationTime)
     {
+        if (IsInifiniteExpiration(expirationTime))
+        {
+            return keys.ToDictionary(k => k, _ => 0U);
+        }
+
+        Debug.Assert(expirationTime != null, nameof(expirationTime) + " != null");
+        
         var utcNow = DateTimeOffset.UtcNow;
         
-        return GetExpirationInternal(keys, utcNow, expirationTime);
+        return GetExpirationInternal(keys, utcNow, expirationTime.Value);
     }
     
     /// <inheritdoc />
     public Dictionary<string, uint> GetExpiration(IEnumerable<string> keys, DateTimeOffset? expirationTime)
     {
-        TimeSpan? timeSpan = null;
-        var utcNow = DateTimeOffset.UtcNow;
-        
-        if (expirationTime.HasValue && expirationTime.Value > utcNow)
+        if (IsInifiniteExpiration(expirationTime))
         {
-            timeSpan = expirationTime.Value.Subtract(utcNow);
+            return keys.ToDictionary(k => k, _ => 0U);
         }
+
+        Debug.Assert(expirationTime != null, nameof(expirationTime) + " != null");
+
+        var utcNow = DateTimeOffset.UtcNow;
+
+        if (expirationTime.Value <= utcNow)
+        {
+            // means expiration time is in the past - don't save anything
+            return new Dictionary<string, uint>();
+        }
+
+        var timeSpan = expirationTime.Value.Subtract(utcNow);
 
         return GetExpirationInternal(keys, utcNow, timeSpan);
     }
@@ -63,7 +83,7 @@ public class ExpirationCalculator: IExpirationCalculator
     private Dictionary<string, uint> GetExpirationInternal(
         IEnumerable<string> keys, 
         DateTimeOffset utcNow,
-        TimeSpan? expirationTime)
+        TimeSpan expirationTime)
     {
         var result = new Dictionary<string, uint>();
 
@@ -71,42 +91,45 @@ public class ExpirationCalculator: IExpirationCalculator
         {
             foreach (var key in keys)
             {
-                result[key] = expirationTime.HasValue 
-                    ? GetExpirationTimeInUnixTimeSeconds(utcNow, expirationTime.Value) 
-                    : 0;
+                result[key] = GetExpirationTimeInUnixTimeSeconds(utcNow, expirationTime);
             }
         }
         else
         {
             foreach (var key in keys)
             {
-                var expirationWithJitter = GetExpirationWithJitter(key, expirationTime);
-
-                result[key] = GetExpirationTimeInUnixTimeSeconds(utcNow, expirationWithJitter);
+                result[key] = GetExpirationTimeInUnixTimeSeconds(
+                    utcNow,
+                    GetExpirationWithJitter(key, expirationTime));
             }
         }
 
         return result;
     }
 
-    private TimeSpan GetExpirationWithJitter(string key, TimeSpan? expirationTime)
+    private TimeSpan GetExpirationWithJitter(string key, TimeSpan expirationTime)
     {
-        if (!expirationTime.HasValue)
-        {
-            return TimeSpan.Zero;
-        }
-        
         var hash = _hashCalculator.ComputeHash(key);
         var lastDigit = hash % _expirationJitterSettings.SpreadFactor;
         var jitter = lastDigit * _expirationJitterSettings.MultiplicationFactor;
 
-        var expirationWithJitter = expirationTime.Value.Add(TimeSpan.FromSeconds(jitter));
+        var expirationWithJitter = expirationTime.Add(TimeSpan.FromSeconds(jitter));
 
         return expirationWithJitter;
     }
 
-    private uint GetExpirationTimeInUnixTimeSeconds(DateTimeOffset timeOffset, TimeSpan expirationTime)
-    {
-        return (uint)(timeOffset + expirationTime).ToUnixTimeSeconds();
-    }
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint GetExpirationTimeInUnixTimeSeconds(DateTimeOffset timeOffset, TimeSpan expirationTime) 
+        => (uint)(timeOffset + expirationTime).ToUnixTimeSeconds();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsInifiniteExpiration(TimeSpan? expirationTime) 
+        => !expirationTime.HasValue
+        || expirationTime == TimeSpan.MaxValue
+        || expirationTime == TimeSpan.Zero;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsInifiniteExpiration(DateTimeOffset? expirationTime) 
+        => !expirationTime.HasValue
+        || expirationTime == DateTimeOffset.MaxValue;
 }

--- a/src/Aer.Memcached.Client/Interfaces/IMemcachedClient.cs
+++ b/src/Aer.Memcached.Client/Interfaces/IMemcachedClient.cs
@@ -81,6 +81,20 @@ public interface IMemcachedClient
 		uint replicationFactor = 0);
 
 	/// <summary>
+	/// Gets multiple values by keys. Does not throw exceptions.
+	/// </summary>
+	/// <param name="keys">Keys</param>
+	/// <param name="token">Cancellation token</param>
+	/// <param name="batchingOptions">The options that configure internal keys batching</param>
+	/// <param name="replicationFactor">Number of physical nodes which will be requested to obtain data</param>
+	/// <returns>Values by keys. Only found in memcached keys are returned</returns>
+	Task<MemcachedClientValueResult<IDictionary<string, T>>> MultiGetSafeAsync<T>(
+		IEnumerable<string> keys,
+		CancellationToken token,
+		BatchingOptions batchingOptions = null,
+		uint replicationFactor = 0);
+
+	/// <summary>
 	/// Deletes one value by key
 	/// </summary>
 	/// <param name="key">Key</param>

--- a/src/Aer.Memcached.Client/Interfaces/IMemcachedClient.cs
+++ b/src/Aer.Memcached.Client/Interfaces/IMemcachedClient.cs
@@ -31,7 +31,7 @@ public interface IMemcachedClient
 	/// <param name="batchingOptions">The options that configure internal key-values batching</param>
 	/// <param name="cacheSyncOptions">The options that configure cache sync</param>
 	/// <param name="replicationFactor">Number of physical nodes replication of data</param>
-	Task MultiStoreAsync<T>(
+	Task<MemcachedClientResult> MultiStoreAsync<T>(
 		Dictionary<string, T> keyValues, 
 		TimeSpan? expirationTime, 
 		CancellationToken token, 
@@ -50,7 +50,7 @@ public interface IMemcachedClient
 	/// <param name="batchingOptions">The options that configure internal key-values batching</param>
 	/// <param name="cacheSyncOptions">The options that configure cache sync</param>
 	/// <param name="replicationFactor">Number of physical nodes replication of data</param>
-	Task MultiStoreAsync<T>(
+	Task<MemcachedClientResult> MultiStoreAsync<T>(
 		Dictionary<string, T> keyValues,
 		DateTimeOffset? expirationTime,
 		CancellationToken token,
@@ -95,7 +95,7 @@ public interface IMemcachedClient
 	/// <param name="batchingOptions">The options that configure internal keys batching</param>
 	/// <param name="cacheSyncOptions">The options that configure cache sync</param>
 	/// <param name="replicationFactor">Number of physical nodes to try delete keys</param>
-	Task MultiDeleteAsync(
+	Task<MemcachedClientResult> MultiDeleteAsync(
 		IEnumerable<string> keys,
 		CancellationToken token,
 		BatchingOptions batchingOptions = null,
@@ -137,5 +137,5 @@ public interface IMemcachedClient
 	/// <summary>
 	/// Flush memcached data
 	/// </summary>
-	Task FlushAsync(CancellationToken token);
+	Task<MemcachedClientResult> FlushAsync(CancellationToken token);
 }

--- a/src/Aer.Memcached.Client/MemcachedClient.cs
+++ b/src/Aer.Memcached.Client/MemcachedClient.cs
@@ -125,10 +125,15 @@ public class MemcachedClient<TNode> : IMemcachedClient where TNode : class, INod
     {
         try
         {
+            if (keyValues is null or {Count: 0})
+            {
+                return MemcachedClientResult.Successful;
+            }
+
             var keyToExpirationMap = _expirationCalculator.GetExpiration(keyValues.Keys, expirationTime);
 
             // this check is first since it shortcuts all of the following logic
-            if (keyToExpirationMap.Count == 0)
+            if (keyToExpirationMap is null)
             {
                 return MemcachedClientResult.Unsuccessful(
                     $"Expiration date time offset {expirationTime} lies in the past. No keys stored");

--- a/src/Aer.Memcached.Client/MemcachedClient.cs
+++ b/src/Aer.Memcached.Client/MemcachedClient.cs
@@ -203,6 +203,28 @@ public class MemcachedClient<TNode> : IMemcachedClient where TNode : class, INod
     }
 
     /// <inheritdoc />
+    public async Task<MemcachedClientValueResult<IDictionary<string, T>>> MultiGetSafeAsync<T>(
+        IEnumerable<string> keys,
+        CancellationToken token,
+        BatchingOptions batchingOptions = null,
+        uint replicationFactor = 0)
+    {
+        try
+        {
+            var getKeysResult = await MultiGetAsync<T>(keys, token, batchingOptions, replicationFactor);
+
+            return MemcachedClientValueResult<IDictionary<string, T>>.Successful(
+                getKeysResult,
+                isResultEmpty: getKeysResult.Count > 0);
+        }
+        catch (Exception e)
+        {
+            return MemcachedClientValueResult<IDictionary<string, T>>.Unsuccessful(
+                $"An exception happened during {nameof(MultiGetSafeAsync)} execution.\nException details: {e}");
+        }
+    }
+
+    /// <inheritdoc />
     public async Task<IDictionary<string, T>> MultiGetAsync<T>(
         IEnumerable<string> keys,
         CancellationToken token,

--- a/src/Aer.Memcached.Client/Models/MemcachedClientResult.cs
+++ b/src/Aer.Memcached.Client/Models/MemcachedClientResult.cs
@@ -2,15 +2,28 @@ namespace Aer.Memcached.Client.Models;
 
 public class MemcachedClientResult
 {
-    public bool Success { get; set; }
+    /// <summary>
+    /// If set to <c>true</c>, then no errors occured on memcached side.
+    /// </summary>
+    public bool Success { get; }
+
+    /// <summary>
+    /// If any errors occured on memcached side, this property contains the error message.
+    /// </summary>
+    public string ErrorMessage { get; }
+
+    public static MemcachedClientResult Successful { get; } = new(success: true);
     
-    public static MemcachedClientResult Unsuccessful { get; } = new()
+    internal MemcachedClientResult(bool success, string errorMessage = null)
     {
-        Success = false
-    };
+        Success = success;
+        ErrorMessage = errorMessage;
+    }
+
+    public static MemcachedClientResult Unsuccessful(string errorMessage)
+    {
+        return new MemcachedClientResult(success: false, errorMessage);
+    }
     
-    public static MemcachedClientResult Successful { get; } = new()
-    {
-        Success = true
-    };
+    
 }

--- a/src/Aer.Memcached.Client/Models/MemcachedClientValueResult.cs
+++ b/src/Aer.Memcached.Client/Models/MemcachedClientValueResult.cs
@@ -2,22 +2,42 @@ namespace Aer.Memcached.Client.Models;
 
 public class MemcachedClientValueResult<T>
 {
-    public T Result { get; set; }
+    /// <summary>
+    /// The result of the memcached operation.
+    /// </summary>
+    public T Result { get; }
     
     /// <summary>
-    /// No errors occured on memcached side
+    /// If set to <c>true</c>, then no errors occured on memcached side.
     /// </summary>
-    public bool Success { get; set; }
+    public bool Success { get; }
 
     /// <summary>
-    /// true - if no value is stored
-    /// default value is true as command to memcached can be unsuccessful
+    /// If any errors occured on memcached side, this property contains the error message.
     /// </summary>
-    public bool IsEmptyResult { get; set; } = true;
+    public string ErrorMessage { get; }
 
-    public static MemcachedClientValueResult<T> Unsuccessful { get; } = new()
+    /// <summary>
+    /// <c>true</c> - if no value is stored
+    /// default value is <c>true</c> as command to memcached can be unsuccessful
+    /// </summary>
+    public bool IsEmptyResult { get; }
+
+    internal MemcachedClientValueResult(
+        bool success,
+        T result = default,
+        bool isEmptyResult = true,
+        string errorMessage = null)
     {
-        Success = false,
-        Result = default
-    };
+        Success = success;
+        Result = result;
+        ErrorMessage = errorMessage;
+        IsEmptyResult = isEmptyResult;
+    }
+
+    internal static MemcachedClientValueResult<T> Successful(T result, bool isResultEmpty)
+        => new(success: true, result: result, isEmptyResult: isResultEmpty);
+
+    internal static MemcachedClientValueResult<T> Unsuccessful(string errorMessage) 
+        => new(success: false, errorMessage: errorMessage);
 }

--- a/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.cs
+++ b/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.cs
@@ -241,6 +241,26 @@ public class MemcachedClientTests : MemcachedClientTestsBase
     }
 
     [TestMethod]
+    public async Task StoreAndGet_NullExpiration()
+    {
+        var key = Guid.NewGuid().ToString();
+        var value = Fixture.Create<SimpleObject>();
+
+        await Client.StoreAsync(
+            key, 
+            value, 
+            expirationTime: null, 
+            CancellationToken.None);
+
+        var getValue = await Client.GetAsync<SimpleObject>(key, CancellationToken.None);
+
+        getValue.Success.Should().BeTrue();
+        
+        getValue.IsEmptyResult.Should().BeFalse();
+        getValue.Result.Should().BeEquivalentTo(value);
+    }
+
+    [TestMethod]
     public async Task StoreAndGet_SimpleObject()
     {
         var key = Guid.NewGuid().ToString();
@@ -273,6 +293,80 @@ public class MemcachedClientTests : MemcachedClientTestsBase
         {
             getValues[keyValue.Key].Should().BeEquivalentTo(keyValues[keyValue.Key]);
         }
+    }
+
+    [TestMethod]
+    public async Task MultiStoreAndGet_NullExpiration()
+    {
+        var keyValues = new Dictionary<string, SimpleObject>();
+
+        foreach (var _ in Enumerable.Range(0, 5))
+        {
+            keyValues[Guid.NewGuid().ToString()] = Fixture.Create<SimpleObject>();
+        }
+
+        await Client.MultiStoreAsync(
+            keyValues,
+            expirationTime: (TimeSpan?) null,
+            CancellationToken.None);
+
+        var getValues = await Client.MultiGetAsync<SimpleObject>(keyValues.Keys, CancellationToken.None);
+
+        foreach (var keyValue in keyValues)
+        {
+            getValues[keyValue.Key].Should().BeEquivalentTo(keyValues[keyValue.Key]);
+        }
+    }
+
+    [TestMethod]
+    public async Task MultiStoreAndGet_NullExpirationDateTimeOffset()
+    {
+        var keyValues = new Dictionary<string, SimpleObject>();
+
+        foreach (var _ in Enumerable.Range(0, 5))
+        {
+            keyValues[Guid.NewGuid().ToString()] = Fixture.Create<SimpleObject>();
+        }
+
+        await Client.MultiStoreAsync(
+            keyValues,
+            expirationTime: (DateTimeOffset?) null,
+            CancellationToken.None);
+
+        var getValues = await Client.MultiGetAsync<SimpleObject>(keyValues.Keys, CancellationToken.None);
+
+        foreach (var keyValue in keyValues)
+        {
+            getValues[keyValue.Key].Should().BeEquivalentTo(keyValues[keyValue.Key]);
+        }
+    }
+
+    [TestMethod]
+    public async Task MultiStoreAndGet_ExpirationNowAndInThePast_NoKeysStored()
+    {
+        var keyValues = new Dictionary<string, SimpleObject>();
+
+        foreach (var _ in Enumerable.Range(0, 5))
+        {
+            keyValues[Guid.NewGuid().ToString()] = Fixture.Create<SimpleObject>();
+        }
+
+        await Client.MultiStoreAsync(
+            keyValues,
+            expirationTime: DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(1)),
+            CancellationToken.None);
+
+        await Client.MultiStoreAsync(
+            keyValues,
+            expirationTime: DateTimeOffset.Now,
+            CancellationToken.None);
+
+        var getValues = 
+            await Client.MultiGetAsync<SimpleObject>(keyValues.Keys, CancellationToken.None);
+
+        // no keys should be stored
+        
+        getValues.Count.Should().Be(0);
     }
 
     [TestMethod]

--- a/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.cs
+++ b/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.cs
@@ -351,15 +351,19 @@ public class MemcachedClientTests : MemcachedClientTestsBase
             keyValues[Guid.NewGuid().ToString()] = Fixture.Create<SimpleObject>();
         }
 
-        await Client.MultiStoreAsync(
+        var storeResult = await Client.MultiStoreAsync(
             keyValues,
             expirationTime: DateTimeOffset.Now.Subtract(TimeSpan.FromSeconds(1)),
             CancellationToken.None);
 
-        await Client.MultiStoreAsync(
+        storeResult.Success.Should().BeFalse();
+        
+        storeResult = await Client.MultiStoreAsync(
             keyValues,
             expirationTime: DateTimeOffset.Now,
             CancellationToken.None);
+
+        storeResult.Success.Should().BeFalse();
 
         var getValues = 
             await Client.MultiGetAsync<SimpleObject>(keyValues.Keys, CancellationToken.None);


### PR DESCRIPTION
All public API (except `MultiGetAsync`) is now non-throwing. For `MultiGetAsync` added `MultiGetSafeAsync`  non-throwing counterpart.

Expiration now acts as it is written in spec. `null`, `TimeSpan.Zero`, `TimeSpan.MaxValue`, `DateTimeOffset.MaxValue` expiration parameter results in infinite item storage. 
In case of `DateTimeOffset` expiration, if it is lies in the past or `== DateTimeOffset.UtcNow` no keys will be stored.