### PR TITLE
Minor cache sync refactorings

### DIFF
--- a/src/Aer.Memcached.Client/Aer.Memcached.Client.csproj
+++ b/src/Aer.Memcached.Client/Aer.Memcached.Client.csproj
@@ -35,5 +35,8 @@
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
             <_Parameter1>Aer.Memcached.Tests</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 </Project>

--- a/src/Aer.Memcached.Client/CacheSync/CacheSyncClient.cs
+++ b/src/Aer.Memcached.Client/CacheSync/CacheSyncClient.cs
@@ -14,9 +14,9 @@ using Polly.Retry;
 
 namespace Aer.Memcached.Client.CacheSync;
 
-public class CacheSyncClient: ICacheSyncClient
+internal class CacheSyncClient: ICacheSyncClient
 {
-    private static readonly JsonSerializerSettings JsonSetting = new()
+    private static readonly JsonSerializerSettings _jsonSettings = new()
     {
         Converters = new List<JsonConverter>(new[] {new StringEnumConverter()}),
         NullValueHandling = NullValueHandling.Ignore,
@@ -53,7 +53,7 @@ public class CacheSyncClient: ICacheSyncClient
         try
         {
             var content = new StringContent(
-                JsonConvert.SerializeObject(data, JsonSetting),
+                JsonConvert.SerializeObject(data, _jsonSettings),
                 Encoding.UTF8,
                 MediaTypeNames.Application.Json);
             
@@ -79,7 +79,7 @@ public class CacheSyncClient: ICacheSyncClient
         try
         {
             var content = new StringContent(
-                JsonConvert.SerializeObject(keys, JsonSetting),
+                JsonConvert.SerializeObject(keys, _jsonSettings),
                 Encoding.UTF8,
                 MediaTypeNames.Application.Json);
             

--- a/src/Aer.Memcached.Client/CacheSync/CacheSyncClient.cs
+++ b/src/Aer.Memcached.Client/CacheSync/CacheSyncClient.cs
@@ -96,26 +96,6 @@ internal class CacheSyncClient: ICacheSyncClient
         }
     }
     
-    /// <inheritdoc />
-    public async Task FlushAsync(
-        MemcachedConfiguration.SyncServer syncServer,
-        CancellationToken token)
-    {
-        try
-        {
-            var baseUri = new Uri(syncServer.Address);
-            var endpointUri = new Uri(baseUri, _config.SyncSettings.FlushEndpoint);
-
-            await RequestAsync(null, endpointUri, token);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Unable to flush data on {SyncServerAddress}", syncServer.Address);
-
-            throw;
-        }
-    }
-
     private async Task RequestAsync(StringContent content, Uri endpointUri, CancellationToken token)
     {
         await _retryPolicy.Execute(async () =>

--- a/src/Aer.Memcached.Client/CacheSync/CacheSyncClient.cs
+++ b/src/Aer.Memcached.Client/CacheSync/CacheSyncClient.cs
@@ -16,7 +16,7 @@ namespace Aer.Memcached.Client.CacheSync;
 
 internal class CacheSyncClient: ICacheSyncClient
 {
-    private static readonly JsonSerializerSettings _jsonSettings = new()
+    private static readonly JsonSerializerSettings JsonSettings = new()
     {
         Converters = new List<JsonConverter>(new[] {new StringEnumConverter()}),
         NullValueHandling = NullValueHandling.Ignore,
@@ -53,7 +53,7 @@ internal class CacheSyncClient: ICacheSyncClient
         try
         {
             var content = new StringContent(
-                JsonConvert.SerializeObject(data, _jsonSettings),
+                JsonConvert.SerializeObject(data, JsonSettings),
                 Encoding.UTF8,
                 MediaTypeNames.Application.Json);
             
@@ -79,7 +79,7 @@ internal class CacheSyncClient: ICacheSyncClient
         try
         {
             var content = new StringContent(
-                JsonConvert.SerializeObject(keys, _jsonSettings),
+                JsonConvert.SerializeObject(keys, JsonSettings),
                 Encoding.UTF8,
                 MediaTypeNames.Application.Json);
             

--- a/src/Aer.Memcached.Client/CacheSync/CacheSynchronizer.cs
+++ b/src/Aer.Memcached.Client/CacheSync/CacheSynchronizer.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 
 namespace Aer.Memcached.Client.CacheSync;
 
-public class CacheSynchronizer : ICacheSynchronizer
+internal class CacheSynchronizer : ICacheSynchronizer
 {
     private readonly ISyncServersProvider _syncServersProvider;
     private readonly ICacheSyncClient _cacheSyncClient;
@@ -36,10 +36,13 @@ public class CacheSynchronizer : ICacheSynchronizer
         _serverBySwitchOffTime = new ConcurrentDictionary<string, DateTimeOffset>();
     }
 
+
+    /// <inheritdoc />
+    public bool IsCacheSyncEnabled() => _syncServersProvider.IsConfigured();
+
     /// <inheritdoc />
     public async Task SyncCacheAsync<T>(
         CacheSyncModel<T> model,
-        CacheSyncOptions cacheSyncOptions,
         CancellationToken token)
     {
         if (model.KeyValues == null)
@@ -47,7 +50,7 @@ public class CacheSynchronizer : ICacheSynchronizer
             return;
         }
 
-        if (!_syncServersProvider.IsConfigured())
+        if (!IsCacheSyncEnabled())
         {
             return;
         }
@@ -106,7 +109,7 @@ public class CacheSynchronizer : ICacheSynchronizer
             return;
         }
 
-        if (!_syncServersProvider.IsConfigured())
+        if (!IsCacheSyncEnabled())
         {
             return;
         }

--- a/src/Aer.Memcached.Client/CacheSync/CacheSynchronizer.cs
+++ b/src/Aer.Memcached.Client/CacheSync/CacheSynchronizer.cs
@@ -94,9 +94,13 @@ internal class CacheSynchronizer : ICacheSynchronizer
                     }
                 });
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // no need to crash if something goes wrong with sync
+            // no need to crash if something goes wrong with sync - just log and ignore
+            _logger.LogError(
+                ex,
+                "Exception happened durin cache sync {OperationName} operation",
+                nameof(SyncCacheAsync));
         }
     }
     
@@ -148,9 +152,13 @@ internal class CacheSynchronizer : ICacheSynchronizer
                     }
                 });
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // no need to crash if something goes wrong with sync
+            // no need to crash if something goes wrong with sync - just log and ignore
+            _logger.LogError(
+                ex,
+                "Exception happened durin cache sync {OperationName} operation",
+                nameof(DeleteCacheAsync));
         }
     }
 

--- a/src/Aer.Memcached.Client/CacheSync/CacheSynchronizer.cs
+++ b/src/Aer.Memcached.Client/CacheSync/CacheSynchronizer.cs
@@ -94,13 +94,10 @@ internal class CacheSynchronizer : ICacheSynchronizer
                     }
                 });
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            // no need to crash if something goes wrong with sync - just log and ignore
-            _logger.LogError(
-                ex,
-                "Exception happened durin cache sync {OperationName} operation",
-                nameof(SyncCacheAsync));
+            // this exception was already logged in _cacheSyncClient
+            // no need to crash if something goes wrong with sync 
         }
     }
     
@@ -154,11 +151,8 @@ internal class CacheSynchronizer : ICacheSynchronizer
         }
         catch (Exception ex)
         {
-            // no need to crash if something goes wrong with sync - just log and ignore
-            _logger.LogError(
-                ex,
-                "Exception happened durin cache sync {OperationName} operation",
-                nameof(DeleteCacheAsync));
+            // this exception was already logged in _cacheSyncClient
+            // no need to crash if something goes wrong with sync
         }
     }
 

--- a/src/Aer.Memcached.Client/CacheSync/DefaultSyncServersProvider.cs
+++ b/src/Aer.Memcached.Client/CacheSync/DefaultSyncServersProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace Aer.Memcached.Client.CacheSync;
 
-public class DefaultSyncServersProvider: ISyncServersProvider
+internal class DefaultSyncServersProvider: ISyncServersProvider
 {
     private readonly MemcachedConfiguration _config;
 

--- a/src/Aer.Memcached.Client/Interfaces/ICacheSyncClient.cs
+++ b/src/Aer.Memcached.Client/Interfaces/ICacheSyncClient.cs
@@ -26,13 +26,4 @@ public interface ICacheSyncClient
         MemcachedConfiguration.SyncServer syncServer,
         IEnumerable<string> keys,
         CancellationToken token);
-
-    /// <summary>
-    /// Flush cache data on the specified server
-    /// </summary>
-    /// <param name="syncServer">Server to sync data</param>
-    /// <param name="token">Cancellation token</param>
-    Task FlushAsync(
-        MemcachedConfiguration.SyncServer syncServer,
-        CancellationToken token);
 }

--- a/src/Aer.Memcached.Client/Interfaces/ICacheSynchronizer.cs
+++ b/src/Aer.Memcached.Client/Interfaces/ICacheSynchronizer.cs
@@ -6,17 +6,21 @@ namespace Aer.Memcached.Client.Interfaces;
 public interface ICacheSynchronizer
 {
     /// <summary>
-    /// Syncs data to the servers that are specified in <see cref="MemcachedConfiguration.SynchronizationSettings"/>
+    /// Determines whether the cache sync logic is enabled.
     /// </summary>
-    /// <param name="model">Data to sync</param>
-    /// <param name="cacheSyncOptions">The options that configure cache sync</param>
-    /// <param name="token">Cancellation token</param>
-    Task SyncCacheAsync<T>(CacheSyncModel<T> model, CacheSyncOptions cacheSyncOptions, CancellationToken token);
+    bool IsCacheSyncEnabled();
+    
+    /// <summary>
+    /// Syncs data to the servers that are specified in <see cref="MemcachedConfiguration.SynchronizationSettings"/>.
+    /// </summary>
+    /// <param name="model">Data to sync.</param>
+    /// <param name="token">Cancellation token.</param>
+    Task SyncCacheAsync<T>(CacheSyncModel<T> model, CancellationToken token);
 
     /// <summary>
-    /// Deletes data on the servers that are specified in <see cref="MemcachedConfiguration.SynchronizationSettings"/>
+    /// Deletes data on the servers that are specified in <see cref="MemcachedConfiguration.SynchronizationSettings"/>.
     /// </summary>
-    /// <param name="keys">Keys to delete</param>
-    /// <param name="token">Cancellation token</param>
+    /// <param name="keys">Keys to delete.</param>
+    /// <param name="token">Cancellation token.</param>
     Task DeleteCacheAsync(IEnumerable<string> keys, CancellationToken token);
 }

--- a/src/Aer.Memcached.Client/Interfaces/IMemcachedClient.cs
+++ b/src/Aer.Memcached.Client/Interfaces/IMemcachedClient.cs
@@ -13,13 +13,15 @@ public interface IMemcachedClient
 	/// <param name="expirationTime">Expiration time</param>
 	/// <param name="token">Cancellation token</param>
 	/// <param name="storeMode">Store mode</param>
+	/// <param name="cacheSyncOptions">The options that configure cache sync</param>
 	/// <returns>Result that shows if operation was successful or not</returns>
 	Task<MemcachedClientResult> StoreAsync<T>(
 		string key,
 		T value,
 		TimeSpan? expirationTime,
 		CancellationToken token,
-		StoreMode storeMode = StoreMode.Set);
+		StoreMode storeMode = StoreMode.Set,
+		CacheSyncOptions cacheSyncOptions = null);
 
 	/// <summary>
 	/// Stores multiple values
@@ -99,7 +101,11 @@ public interface IMemcachedClient
 	/// </summary>
 	/// <param name="key">Key</param>
 	/// <param name="token">Cancellation token</param>
-	Task<MemcachedClientResult> DeleteAsync(string key, CancellationToken token);
+	/// <param name="cacheSyncOptions">The options that configure cache sync</param>
+	Task<MemcachedClientResult> DeleteAsync(
+		string key, 
+		CancellationToken token, 
+		CacheSyncOptions cacheSyncOptions = null);
 
 	/// <summary>
 	/// Deletes multiple values by keys

--- a/src/Aer.Memcached.Client/Interfaces/ISyncServersProvider.cs
+++ b/src/Aer.Memcached.Client/Interfaces/ISyncServersProvider.cs
@@ -5,14 +5,14 @@ namespace Aer.Memcached.Client.Interfaces;
 public interface ISyncServersProvider
 {
     /// <summary>
-    /// Gets sync servers
+    /// Gets sync servers.
     /// </summary>
     /// <returns>Sync servers</returns>
     MemcachedConfiguration.SyncServer[] GetSyncServers();
 
     /// <summary>
-    /// Provider is configured or not
+    /// Returns <c>true</c> if sync servers provider is configured, <c>false</c> otherwise.
+    /// Used to determine whether the cache sync is enabled or not. 
     /// </summary>
-    /// <returns>Flag</returns>
     bool IsConfigured();
 }

--- a/tests/Aer.Memcached.Tests/TestClasses/CacheSynchronizerTests.cs
+++ b/tests/Aer.Memcached.Tests/TestClasses/CacheSynchronizerTests.cs
@@ -45,7 +45,7 @@ public class CacheSynchronizerTests
     {
         var cacheSynchronizer = GetCacheSynchronizer();
 
-        await cacheSynchronizer.SyncCacheAsync(new CacheSyncModel<string>(), new CacheSyncOptions(), CancellationToken.None);
+        await cacheSynchronizer.SyncCacheAsync(new CacheSyncModel<string>(), CancellationToken.None);
 
         await _cacheSyncClient.Received(0).SyncAsync(Arg.Any<MemcachedConfiguration.SyncServer>(),
             Arg.Any<CacheSyncModel<string>>(), Arg.Any<CancellationToken>());
@@ -79,7 +79,7 @@ public class CacheSynchronizerTests
         await cacheSynchronizer.SyncCacheAsync(new CacheSyncModel<string>{
             KeyValues = _fixture.Create<Dictionary<string, string>>(),
             ExpirationTime = _fixture.Create<DateTimeOffset>()
-        }, new CacheSyncOptions(), CancellationToken.None);
+        }, CancellationToken.None);
 
         await _cacheSyncClient.Received(syncServers.Length).SyncAsync(Arg.Any<MemcachedConfiguration.SyncServer>(),
             Arg.Any<CacheSyncModel<string>>(), Arg.Any<CancellationToken>());
@@ -121,7 +121,7 @@ public class CacheSynchronizerTests
         await cacheSynchronizer.SyncCacheAsync(new CacheSyncModel<string>{
             KeyValues = _fixture.Create<Dictionary<string, string>>(),
             ExpirationTime = _fixture.Create<DateTimeOffset>()
-        }, new CacheSyncOptions(), CancellationToken.None);
+        }, CancellationToken.None);
 
         await _cacheSyncClient.Received(syncServers.Length).SyncAsync(Arg.Any<MemcachedConfiguration.SyncServer>(),
             Arg.Any<CacheSyncModel<string>>(), Arg.Any<CancellationToken>());
@@ -173,7 +173,7 @@ public class CacheSynchronizerTests
         {
             KeyValues = _fixture.Create<Dictionary<string, string>>(),
             ExpirationTime = _fixture.Create<DateTimeOffset>()
-        }, new CacheSyncOptions(), CancellationToken.None);
+        }, CancellationToken.None);
 
         await _cacheSyncClient.Received(syncServers.Length).SyncAsync(Arg.Any<MemcachedConfiguration.SyncServer>(),
             Arg.Any<CacheSyncModel<string>>(), Arg.Any<CancellationToken>());
@@ -239,7 +239,7 @@ public class CacheSynchronizerTests
         await cacheSynchronizer.SyncCacheAsync(new CacheSyncModel<string>{
             KeyValues = _fixture.Create<Dictionary<string, string>>(),
             ExpirationTime = _fixture.Create<DateTimeOffset>()
-        }, new CacheSyncOptions(), CancellationToken.None);
+        }, CancellationToken.None);
 
         await _cacheSyncClient.Received(1).SyncAsync(syncServerNotTurnedOff,
             Arg.Any<CacheSyncModel<string>>(), Arg.Any<CancellationToken>());
@@ -253,7 +253,7 @@ public class CacheSynchronizerTests
         await cacheSynchronizer.SyncCacheAsync(new CacheSyncModel<string>{
             KeyValues = _fixture.Create<Dictionary<string, string>>(),
             ExpirationTime = _fixture.Create<DateTimeOffset>()
-        }, new CacheSyncOptions(), CancellationToken.None);
+        }, CancellationToken.None);
 
         await _cacheSyncClient.Received(2).SyncAsync(syncServerNotTurnedOff,
             Arg.Any<CacheSyncModel<string>>(), Arg.Any<CancellationToken>());


### PR DESCRIPTION
- Remove unused Flush method from CaceSyncClient;
- Check whether cache sync is enabled before calling cache sycnhorinizer logc to avoid unnecessary calls and allocations;
- All Store and Delete method variants now support cache synchronization;
