### PR TITLE
Added support to storing the keys longer than 250 bytes

### DIFF
--- a/src/Aer.ConsistentHash/Abstractions/IHashCalculator.cs
+++ b/src/Aer.ConsistentHash/Abstractions/IHashCalculator.cs
@@ -1,6 +1,22 @@
 namespace Aer.ConsistentHash.Abstractions;
 
+/// <summary>
+/// Interface for key or value hash calculator.
+/// </summary>
 public interface IHashCalculator
 {
+    /// <summary>
+    /// Computes the value hash and returns it in a form of <see cref="ulong"/>.
+    /// </summary>
+    /// <param name="value">The value to compute hash for.</param>
     ulong ComputeHash(string value);
+
+    /// <summary>
+    /// Computes the value hash and returns it in a form of <see cref="string"/>.
+    /// </summary>
+    /// <param name="value">The value to digest.</param>
+    /// <remarks>
+    /// Used to shorten the long value to the string 32 symbols long.
+    /// </remarks>
+    string DigestValue(string value);
 }

--- a/src/Aer.ConsistentHash/Aer.ConsistentHash.csproj
+++ b/src/Aer.ConsistentHash/Aer.ConsistentHash.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Standart.Hash.xxHash" Version="4.0.4" />
+        <PackageReference Include="Standart.Hash.xxHash" Version="4.0.5" />
     </ItemGroup>
     
 </Project>

--- a/src/Aer.ConsistentHash/HashCalculator.cs
+++ b/src/Aer.ConsistentHash/HashCalculator.cs
@@ -1,12 +1,22 @@
+using System;
 using Aer.ConsistentHash.Abstractions;
 using Standart.Hash.xxHash;
 
 namespace Aer.ConsistentHash;
 
+/// <inheritdoc/>
 public class HashCalculator : IHashCalculator
 {
+    /// <inheritdoc/>
     public ulong ComputeHash(string value)
     {
         return xxHash64.ComputeHash(value);
+    }
+
+    /// <inheritdoc/>
+    public string DigestValue(string value)
+    {
+        var bytes = xxHash128.ComputeHashBytes(value);
+        return Convert.ToHexString(bytes);
     }
 }

--- a/src/Aer.Memcached.Client/CommandExecutor.cs
+++ b/src/Aer.Memcached.Client/CommandExecutor.cs
@@ -198,7 +198,7 @@ public class CommandExecutor<TNode> : ICommandExecutor<TNode> where TNode : clas
             }
             
             // since we are not using the command internal buffers to read result 
-            // we don't need to dispose the command, this call is here for symmetry or future changes prposes
+            // we don't need to dispose the command, this call is here for symmetry or future changes purposes
             command.Dispose();
 
             if (sucessfullCommand is not null)

--- a/src/Aer.Memcached.Client/Commands/Base/SingleKeyMemcachedCommandBase.cs
+++ b/src/Aer.Memcached.Client/Commands/Base/SingleKeyMemcachedCommandBase.cs
@@ -5,15 +5,18 @@ using Aer.Memcached.Client.ConnectionPool;
 
 namespace Aer.Memcached.Client.Commands.Base;
 
-internal abstract class SingleItemCommandBase: MemcachedCommandBase
+internal abstract class SingleKeyMemcachedCommandBase: MemcachedCommandBase
 {
     protected string Key { get; }
-    
+
+    protected string SafeLengthKey { get; }
+
     protected ulong CasValue { get; set; }
 
-    protected SingleItemCommandBase(string key, OpCode opCode): base(opCode)
+    protected SingleKeyMemcachedCommandBase(string key, OpCode opCode): base(opCode)
     {
         Key = key;
+        SafeLengthKey = GetSafeLengthKey(key);
     }
     
     protected abstract CommandResult ProcessResponse(BinaryResponseReader responseReader);
@@ -22,7 +25,7 @@ internal abstract class SingleItemCommandBase: MemcachedCommandBase
 
     internal override IList<ArraySegment<byte>> GetBuffer()
     {
-        return Build(Key).CreateBuffer();
+        return Build(SafeLengthKey).CreateBuffer();
     }
 
     protected override CommandResult ReadResponseCore(PooledSocket socket)

--- a/src/Aer.Memcached.Client/Commands/DecrCommand.cs
+++ b/src/Aer.Memcached.Client/Commands/DecrCommand.cs
@@ -7,7 +7,7 @@ using Aer.Memcached.Client.Commands.Infrastructure;
 
 namespace Aer.Memcached.Client.Commands;
 
-internal class DecrCommand: SingleItemCommandBase
+internal class DecrCommand: SingleKeyMemcachedCommandBase
 {
     private readonly ulong _amountToSubtract;
     private readonly ulong _initialValue;
@@ -15,9 +15,11 @@ internal class DecrCommand: SingleItemCommandBase
 
     public ulong Result { get; private set; }
 
-    public DecrCommand(string key, ulong amountToSubtract, ulong initialValue, uint expiresAtUnixTimeSeconds) : base(
-        key,
-        OpCode.Decrement)
+    public DecrCommand(
+        string key,
+        ulong amountToSubtract,
+        ulong initialValue,
+        uint expiresAtUnixTimeSeconds) : base(key, OpCode.Decrement)
     {
         _amountToSubtract = amountToSubtract;
         _initialValue = initialValue;

--- a/src/Aer.Memcached.Client/Commands/DeleteCommand.cs
+++ b/src/Aer.Memcached.Client/Commands/DeleteCommand.cs
@@ -6,7 +6,7 @@ using Aer.Memcached.Client.Commands.Infrastructure;
 
 namespace Aer.Memcached.Client.Commands;
 
-internal class DeleteCommand: SingleItemCommandBase
+internal class DeleteCommand: SingleKeyMemcachedCommandBase
 {
     public DeleteCommand(string key) : base(key, OpCode.Delete)
     {

--- a/src/Aer.Memcached.Client/Commands/GetCommand.cs
+++ b/src/Aer.Memcached.Client/Commands/GetCommand.cs
@@ -7,7 +7,7 @@ using Aer.Memcached.Client.Models;
 
 namespace Aer.Memcached.Client.Commands;
 
-internal class GetCommand: SingleItemCommandBase
+internal class GetCommand: SingleKeyMemcachedCommandBase
 {
     public CacheItemResult Result { get; private set; }
 

--- a/src/Aer.Memcached.Client/Commands/GetCommand.cs
+++ b/src/Aer.Memcached.Client/Commands/GetCommand.cs
@@ -9,13 +9,13 @@ namespace Aer.Memcached.Client.Commands;
 
 internal class GetCommand: SingleKeyMemcachedCommandBase
 {
+    internal override bool HasResult => Result is not null;
+    
     public CacheItemResult Result { get; private set; }
 
     public GetCommand(string key) : base(key, OpCode.Get)
     {
     }
-
-    internal override bool HasResult => Result is not null;
 
     protected override BinaryRequest Build(string key)
     {

--- a/src/Aer.Memcached.Client/Commands/IncrCommand.cs
+++ b/src/Aer.Memcached.Client/Commands/IncrCommand.cs
@@ -15,7 +15,11 @@ internal class IncrCommand: SingleKeyMemcachedCommandBase
 
     public ulong Result { get; private set; }
 
-    public IncrCommand(string key, ulong amountToAdd, ulong initialValue, uint expiresAtUnixTimeSeconds) : base(key, OpCode.Increment)
+    public IncrCommand(
+        string key,
+        ulong amountToAdd,
+        ulong initialValue,
+        uint expiresAtUnixTimeSeconds) : base(key, OpCode.Increment)
     {
         _amountToAdd = amountToAdd;
         _initialValue = initialValue;

--- a/src/Aer.Memcached.Client/Commands/IncrCommand.cs
+++ b/src/Aer.Memcached.Client/Commands/IncrCommand.cs
@@ -7,7 +7,7 @@ using Aer.Memcached.Client.Commands.Infrastructure;
 
 namespace Aer.Memcached.Client.Commands;
 
-internal class IncrCommand: SingleItemCommandBase
+internal class IncrCommand: SingleKeyMemcachedCommandBase
 {
     private readonly ulong _amountToAdd;
     private readonly ulong _initialValue;

--- a/src/Aer.Memcached.Client/Commands/MultiDeleteCommand.cs
+++ b/src/Aer.Memcached.Client/Commands/MultiDeleteCommand.cs
@@ -18,7 +18,7 @@ internal class MultiDeleteCommand: MemcachedCommandBase
 
     public MultiDeleteCommand(IEnumerable<string> keys, int keysCount): base(OpCode.DeleteQ)
     {
-        _keys = keys;
+        _keys = keys.Select(GetSafeLengthKey);
         _keysCount = keysCount;
     }
 

--- a/src/Aer.Memcached.Client/Commands/MultiStoreCommand.cs
+++ b/src/Aer.Memcached.Client/Commands/MultiStoreCommand.cs
@@ -94,7 +94,7 @@ internal class MultiStoreCommand: MemcachedCommandBase
 
             var request = new BinaryRequest(OpCode)
             {
-                Key = key,
+                Key = GetSafeLengthKey(key),
                 Cas = casValue,
                 Extra = new ArraySegment<byte>(span.ToArray()),
                 Data = cacheItem.Data

--- a/src/Aer.Memcached.Client/Commands/StoreCommand.cs
+++ b/src/Aer.Memcached.Client/Commands/StoreCommand.cs
@@ -8,12 +8,16 @@ using Aer.Memcached.Client.Models;
 
 namespace Aer.Memcached.Client.Commands;
 
-internal class StoreCommand: SingleItemCommandBase
+internal class StoreCommand: SingleKeyMemcachedCommandBase
 {
     private readonly CacheItemForRequest _cacheItem;
     private readonly uint _expiresAtUnixTimeSeconds;
 
-    public StoreCommand(StoreMode storeMode, string key, CacheItemForRequest cacheItem, uint expiresAtUnixTimeSeconds) : base(key, storeMode.Resolve())
+    public StoreCommand(
+        StoreMode storeMode,
+        string key,
+        CacheItemForRequest cacheItem,
+        uint expiresAtUnixTimeSeconds) : base(key, storeMode.Resolve())
     {
         _cacheItem = cacheItem;
         _expiresAtUnixTimeSeconds = expiresAtUnixTimeSeconds;

--- a/tests/Aer.ConsistentHash.Tests/TestClasses/HashCalculatorTests.cs
+++ b/tests/Aer.ConsistentHash.Tests/TestClasses/HashCalculatorTests.cs
@@ -1,0 +1,20 @@
+﻿using Aer.ConsistentHash.Abstractions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Aer.ConsistentHash.Tests.TestClasses;
+
+[TestClass]
+public class HashCalculatorTests
+{
+	[TestMethod]
+	public void TestDigestKeyValue()
+	{
+		IHashCalculator hasher = new HashCalculator();
+		var testKey = "Test";
+
+		var digestedValue = hasher.DigestValue(testKey);
+
+		digestedValue.Length.Should().Be(32);
+	}
+}

--- a/tests/Aer.ConsistentHash.Tests/TestClasses/HashRingTests.cs
+++ b/tests/Aer.ConsistentHash.Tests/TestClasses/HashRingTests.cs
@@ -5,7 +5,7 @@ using Aer.ConsistentHash.Tests.Model;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Aer.ConsistentHash.Tests;
+namespace Aer.ConsistentHash.Tests.TestClasses;
 
 [TestClass]
 public class HashRingTests

--- a/tests/Aer.ConsistentHash.Tests/TestClasses/HashRingTests.cs
+++ b/tests/Aer.ConsistentHash.Tests/TestClasses/HashRingTests.cs
@@ -31,7 +31,7 @@ public class HashRingTests
 
         node.Should().BeEquivalentTo(nodeToAdd);
     }
-    
+
     [TestMethod]
     public void GetNode_MultipleNodeAdded_ReturnsNode()
     {
@@ -43,14 +43,14 @@ public class HashRingTests
 
         nodesToAdd.Should().Contain(node);
     }
-    
+
     [TestMethod]
     public void GetNodes_MultipleNodeAdded_ReturnsNodes()
     {
         var hashRing = GetHashRing();
 
         var nodesToAdd = Enumerable.Range(0, 5).Select(_ => new TestHashRingNode()).ToArray();
-        
+
         hashRing.AddNodes(nodesToAdd);
         var nodes = hashRing.GetNodes(new[] {"test", "test2"}, replicationFactor: 0);
 
@@ -68,7 +68,7 @@ public class HashRingTests
         var nodesToInitiallyAdd = Enumerable.Range(0, 15)
             .Select(_ => new TestHashRingNode())
             .ToArray();
-        
+
         hashRing.AddNodes(nodesToInitiallyAdd);
 
         var nodesToAdd = Enumerable.Range(0, 15)
@@ -79,10 +79,7 @@ public class HashRingTests
             () =>
                 Parallel.ForEach(
                     nodesToAdd,
-                    nodeToAdd =>
-                    {
-                        hashRing.AddNode(nodeToAdd);
-                    }
+                    nodeToAdd => { hashRing.AddNode(nodeToAdd); }
                 )
         );
 
@@ -91,10 +88,7 @@ public class HashRingTests
         var keysToGet = new[] {"test", "test2"};
 
         var taskToGetNodes = Task.Run(
-            () =>
-            {
-                nodes = hashRing.GetNodesWithoutReplicas(keysToGet);
-            }
+            () => { nodes = hashRing.GetNodesWithoutReplicas(keysToGet); }
         );
 
         await Task.WhenAll(taskToAddNodes, taskToGetNodes);
@@ -138,12 +132,9 @@ public class HashRingTests
         var keysToGet = new[] {"test", "test2"};
 
         var taskToGetNodes = Task.Run(
-            () =>
-            {
-                nodes = hashRing.GetNodesWithoutReplicas(keysToGet);
-            }
+            () => { nodes = hashRing.GetNodesWithoutReplicas(keysToGet); }
         );
-        
+
         await Task.WhenAll(taskToAddNodes, taskToRemoveNodes, taskToGetNodes);
 
         nodes.Count.Should().Be(keysToGet.Length);
@@ -159,32 +150,32 @@ public class HashRingTests
         var node = hashRing.GetNode("test");
 
         node.Should().BeEquivalentTo(nodeToAdd);
-        
+
         hashRing.RemoveNode(nodeToAdd);
         node = hashRing.GetNode("test");
         node.Should().BeNull();
     }
-    
+
     [TestMethod]
     public void RemoveNode_NodesAddedAndRemoved_ReturnsEmptyDictionary()
     {
         var hashRing = GetHashRing();
 
         var nodesToAdd = Enumerable.Range(0, 5).Select(_ => new TestHashRingNode()).ToArray();
-        
+
         hashRing.AddNodes(nodesToAdd);
 
         var keysToGet = new[] {"test", "test2"};
-        
-        var nodes = hashRing.GetNodesWithoutReplicas(keysToGet); 
+
+        var nodes = hashRing.GetNodesWithoutReplicas(keysToGet);
 
         foreach (var node in nodes)
         {
             nodesToAdd.Should().Contain(node.Key);
         }
-        
+
         hashRing.RemoveNodes(nodesToAdd);
-        
+
         nodes = hashRing.GetNodesWithoutReplicas(keysToGet);
         nodes.Keys.Count.Should().Be(0);
     }
@@ -220,14 +211,14 @@ public class HashRingTests
 
         hashRing.AddNodes(nodesToAdd);
 
-        var replicatedNodes = 
+        var replicatedNodes =
             hashRing.GetNodes(new[] {"test"}, replicationFactor: replicationFactor);
 
         var totalNodesCount = replicatedNodes
             .Sum(kv => kv.Key.ReplicaNodes.Count + 1); // +1 to account for primary node
 
         totalNodesCount.Should().Be(totalExpectedNodesCount);
-        
+
         foreach (var replicatedNode in replicatedNodes)
         {
             nodesToAdd.Should().Contain(replicatedNode.Key.PrimaryNode);
@@ -246,7 +237,7 @@ public class HashRingTests
     private INodeLocator<TestHashRingNode> GetHashRing()
     {
         var hashCalculator = new HashCalculator();
-        
+
         return new HashRing<TestHashRingNode>(hashCalculator);
     }
 }

--- a/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientMethodsTestsBase.cs
+++ b/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientMethodsTestsBase.cs
@@ -291,7 +291,7 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
     [TestMethod]
     public async Task StoreAndGet_SimpleObject()
     {
-        var key = Guid.NewGuid().ToString();
+        var key = GetTooLongKey();
         var value = Fixture.Create<SimpleObject>();
 
         await Client.StoreAsync(key, value, TimeSpan.FromSeconds(CacheItemExpirationSeconds), CancellationToken.None);
@@ -312,6 +312,11 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
         {
             keyValues[Guid.NewGuid().ToString()] = Fixture.Create<SimpleObject>();
         }
+
+        // add too long memcached key to the keys collection
+
+        var tooLongKey = GetTooLongKey();
+        keyValues[tooLongKey] = Fixture.Create<SimpleObject>();
     
         await Client.MultiStoreAsync(keyValues, TimeSpan.FromSeconds(CacheItemExpirationSeconds), CancellationToken.None);
     
@@ -332,6 +337,11 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
         {
             keyValues[Guid.NewGuid().ToString()] = Fixture.Create<SimpleObject>();
         }
+
+        // add too long memcached key to the keys collection
+
+        var tooLongKey = GetTooLongKey();
+        keyValues[tooLongKey] = Fixture.Create<SimpleObject>();
 
         await Client.MultiStoreAsync(
             keyValues,
@@ -425,6 +435,11 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
         {
             keyValues[Guid.NewGuid().ToString()] = Guid.NewGuid().ToString();
         }
+
+        // add too long memcached key to the keys collection
+
+        var tooLongKey = GetTooLongKey();
+        keyValues[tooLongKey] = Guid.NewGuid().ToString();
 
         await Client.MultiStoreAsync(
             keyValues,
@@ -708,7 +723,7 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
     [TestMethod]
     public async Task Delete_Successful()
     {
-        var key = Guid.NewGuid().ToString();
+        var key = GetTooLongKey();
         var value = Fixture.Create<SimpleObject>();
 
         await Client.StoreAsync(key, value, TimeSpan.FromSeconds(CacheItemExpirationSeconds), CancellationToken.None);
@@ -727,7 +742,7 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
     [TestMethod]
     public async Task MultiDelete_OneKey_Successful()
     {
-        var key = Guid.NewGuid().ToString();
+        var key = GetTooLongKey();
         var value = Fixture.Create<SimpleObject>();
 
         await Client.StoreAsync(key, value, TimeSpan.FromSeconds(CacheItemExpirationSeconds), CancellationToken.None);
@@ -783,6 +798,11 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
         {
             keyValues[Guid.NewGuid().ToString()] = Fixture.Create<SimpleObject>();
         }
+
+        // add too long memcached key to the keys collection
+
+        var tooLongKey = GetTooLongKey();
+        keyValues[tooLongKey] = Fixture.Create<SimpleObject>();
     
         await Client.MultiStoreAsync(keyValues, TimeSpan.FromSeconds(CacheItemExpirationSeconds), CancellationToken.None);
     
@@ -803,7 +823,7 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
     [TestMethod]
     public async Task Incr_Successful()
     {
-        var key = Guid.NewGuid().ToString();
+        var key = GetTooLongKey();
         ulong initialValue = 0;
 
         var incrValue = await Client.IncrAsync(
@@ -828,7 +848,7 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
     [TestMethod]
     public async Task Incr_InitialValueNotZero_Successful()
     {
-        var key = Guid.NewGuid().ToString();
+        var key = GetTooLongKey();
         ulong initialValue = 15;
 
         var incrValue = await Client.IncrAsync(
@@ -862,7 +882,7 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
     [TestMethod]
     public async Task Decr_Successful()
     {
-        var key = Guid.NewGuid().ToString();
+        var key = GetTooLongKey();
         ulong initialValue = 15;
 
         var incrValue = await Client.DecrAsync(
@@ -887,7 +907,7 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
     [TestMethod]
     public async Task Decr_ToLessThanZero_DecrementedToZero()
     {
-        var key = Guid.NewGuid().ToString();
+        var key = GetTooLongKey();
         ulong initialValue = 5;
 
         var incrValue = await Client.DecrAsync(
@@ -946,10 +966,15 @@ public class MemcachedClientMethodsTestsBase : MemcachedClientTestsBase
 
     private string GetTooLongKey()
     {
+        var uniquePart = Guid.NewGuid().ToString();
+        
         var tooLongKey =
+            uniquePart
+            +
             new string(
                 '*',
-                MemcachedCommandBase.MemcachedKeyLengthMaxLengthBytes + 1); // this key is too long to be stored
+                // this length is 1 byte too long to be stored
+                MemcachedCommandBase.MemcachedKeyLengthMaxLengthBytes - uniquePart.Length + 1); 
 
         return tooLongKey;
     }

--- a/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.CustomSerializer.cs
+++ b/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.CustomSerializer.cs
@@ -14,6 +14,9 @@ namespace Aer.Memcached.Tests.TestClasses;
 // ReSharper disable once InconsistentNaming
 public class MemcachedClientTests_CustomSerializer : MemcachedClientTestsBase
 {
+	// NOTE: custom TestObjectBinarySerializer serializer is identical to MessagePack serializer
+	// Thus these tests do not inherit from MemcachedClientMethodsTestsBase to avoid testing already tested behavior
+	
 	public MemcachedClientTests_CustomSerializer() 
 		: base(isSingleNodeCluster: true, binarySerializerType: ObjectBinarySerializerType.Custom)
 	{ }

--- a/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.DefaultBsonSerializer.cs
+++ b/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.DefaultBsonSerializer.cs
@@ -1,0 +1,20 @@
+﻿using Aer.Memcached.Client.Config;
+using Aer.Memcached.Client.Interfaces;
+using Aer.Memcached.Tests.Base;
+using Aer.Memcached.Tests.Infrastructure;
+using Aer.Memcached.Tests.Model.StoredObjects;
+using AutoFixture;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Aer.Memcached.Tests.TestClasses;
+
+[TestClass]
+// ReSharper disable once InconsistentNaming
+public class MemcachedClientTests_DefaultBsonSerializer : MemcachedClientMethodsTestsBase
+{
+	public MemcachedClientTests_DefaultBsonSerializer() 
+		: base(binarySerializerType: ObjectBinarySerializerType.Bson)
+	{ }
+}

--- a/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.MessagePackSerializer.cs
+++ b/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.MessagePackSerializer.cs
@@ -5,7 +5,7 @@ namespace Aer.Memcached.Tests.TestClasses;
 
 [TestClass]
 // ReSharper disable once InconsistentNaming
-public class MemcachedClientTests_MessagePackSerializer : MemcachedClientTests
+public class MemcachedClientTests_MessagePackSerializer : MemcachedClientMethodsTestsBase
 {
 	public MemcachedClientTests_MessagePackSerializer() : base(
 		binarySerializerType: ObjectBinarySerializerType.MessagePack)

--- a/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.cs
+++ b/tests/Aer.Memcached.Tests/TestClasses/MemcachedClientTests.cs
@@ -19,6 +19,9 @@ namespace Aer.Memcached.Tests.TestClasses;
 [TestClass]
 public class MemcachedClientTests : MemcachedClientTestsBase
 {
+    // NOTE: FOR SOME REASON MS TEST DISCOVERY FAILES TO DISCOVER TESTS IN THIS CLASS
+    // CHECK THIS OUT!
+    
     public MemcachedClientTests(
         ObjectBinarySerializerType binarySerializerType = ObjectBinarySerializerType.Bson) : base(
         isSingleNodeCluster: true,


### PR DESCRIPTION
Memcached has a by-design limitation for keys to - they should be no longer than 250 bytes.

This PR lifts this limitation by first checking the key length and, if exceeds the limit, hashing the key using `xxHash128` to a fixed length string.